### PR TITLE
Tweaked to solve  'Could not find generator'

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Run `bundle install`
 You can use the generator to install migrations and append spree_globalize assets to
 your app spree manifest file.
 
-    rails g spree_globalize:install
+    rails g spree:globalize:install
 
 This will insert these lines into your spree manifest files:
 


### PR DESCRIPTION
Hey all,
very minor change. 

I'm on Rails 4.2.2 and Ruby 2.2.0p0.
The install command `rails g spree_globalize:install` as instructed in the README threw back:

`Could not find generator 'spree_globalize:install'. Maybe you meant 'spree:globalize:install' or 'spree_gateway:install' or 'spree_i18n:install'` 

So I changed it to `spree:globalize:install` and installs fine. 
Thought I'd see if it was worth altering!

Thanks!