### PR TITLE
add translations preloading to spree_base_scopes, closes #3

### DIFF
--- a/app/models/spree/globalize/translatable.rb
+++ b/app/models/spree/globalize/translatable.rb
@@ -23,6 +23,11 @@ module Spree
           super(params, options)
         end
         alias :search :ransack unless respond_to? :search
+
+        # preload translations
+        def spree_base_scopes
+          super.includes(:translations).references(:translations)
+        end
       end
     end
   end


### PR DESCRIPTION
This should solve the long running N+1 problems without using `default_scope`

See https://github.com/spree/spree/pull/6646 about `spree_base_scopes`

Some testing and feedback is appreciated :)