### PR TITLE
Fixes missing settings in 'store' translation

### DIFF
--- a/app/views/spree/admin/translations/store.html.erb
+++ b/app/views/spree/admin/translations/store.html.erb
@@ -2,6 +2,8 @@
   <%= Spree.t(:editing_resource, resource: Spree::Store.model_name.human) %>
 <% end %>
 
+<%= render 'settings' %>
+
 <div class="row translations">
   <div class="col-md-4">
     <%= render 'fields' %>


### PR DESCRIPTION
Without this fix, store settings are not translatable, due to javascript error. (jQuery not finding the 'settings' partial's locales)