### PR TITLE
Remove unused override

### DIFF
--- a/app/overrides/spree/admin/taxons/edit/add_translations.html.erb.deface
+++ b/app/overrides/spree/admin/taxons/edit/add_translations.html.erb.deface
@@ -1,2 +1,0 @@
-<!-- insert_top 'li' -->
-<%= button_link_to Spree.t(:'i18n.translations'), spree.admin_translations_path('taxons', @taxon.id), class: 'btn-primary', icon: 'translate' %>


### PR DESCRIPTION
This override generates an error during compilation because it cannot be applied. In fact the new way to translate a taxon is to go to the taxonomy page, right click on taxon name and click on "Translate" in the contextual menu.

I think then that this is an old stale override. Is it true?