### PR TITLE
Add missing translation for meta_title in Spree::Product

### DIFF
--- a/app/models/spree/product_decorator.rb
+++ b/app/models/spree/product_decorator.rb
@@ -1,6 +1,6 @@
 module Spree
   Product.class_eval do
-    translates :name, :description, :meta_description, :meta_keywords, :slug,
+    translates :name, :description, :meta_title, :meta_description, :meta_keywords, :slug,
       fallbacks_for_empty_translations: true
 
     friendly_id :slug_candidates, use: [:history, :globalize]

--- a/db/migrate/20171003153758_add_translation_meta_title_to_product.rb
+++ b/db/migrate/20171003153758_add_translation_meta_title_to_product.rb
@@ -1,0 +1,13 @@
+class AddTranslationMetaTitleToProduct < ActiveRecord::Migration[4.2]
+  def change
+    reversible do |dir|
+      dir.up do
+        Spree::Product.add_translation_fields! meta_title: :text
+      end
+
+      dir.down do
+        remove_column :spree_product_translations, :meta_title
+      end
+    end
+  end
+end

--- a/spec/features/translations_spec.rb
+++ b/spec/features/translations_spec.rb
@@ -10,10 +10,14 @@ RSpec.feature "Translations" do
     let!(:product) do
       create(:product,
         name: 'Antimatter',
+        meta_title: 'Antimatter meta_title',
+        meta_description: 'Antimatter meta_description',
         translations: [
           Spree::Product::Translation.new(
             locale: 'pt-BR',
-            name: 'Antimatéria'
+            name: 'Antimatéria',
+            meta_title: 'Antimatéria meta_title',
+            meta_description: 'Antimatéria meta_description'
           )
         ]
       )


### PR DESCRIPTION
Could you backport this feature on 3-1-stable ?