### PR TITLE
Fixed a small bug & updated readme for easier usage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,12 +12,18 @@ env:
 language: ruby
 
 rvm:
+  - 2.4.4
   - 2.3.1
   - 2.2.7
+
+matrix:
+    allow_failures:
+          - gemfile: gemfiles/spree_master.gemfile
 
 gemfile:
   - gemfiles/spree_3_2.gemfile
   - gemfiles/spree_3_3.gemfile
+  - gemfiles/spree_3_4.gemfile
   - gemfiles/spree_master.gemfile
 
 before_install:

--- a/Appraisals
+++ b/Appraisals
@@ -8,6 +8,11 @@ appraise 'spree-3-3' do
   gem 'rails-controller-testing'
 end
 
+appraise 'spree-3-4' do
+  gem 'spree', '~> 3.4.0'
+  gem 'rails-controller-testing'
+end
+
 appraise 'spree-master' do
   gem 'spree', github: 'spree/spree', branch: 'master'
   gem 'rails-controller-testing'

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'spree', github: 'spree/spree', branch: 'master'
-gem 'globalize', github: 'globalize/globalize', branch: 'master'
-gem 'activemodel-serializers-xml'
+gem 'globalize', github: 'globalize/globalize'
 gem 'spree_i18n', github: 'spree-contrib/spree_i18n'
 
 gemspec

--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ Happy translating!
 Add the following to your `Gemfile`:
 
 ```ruby
-gem 'spree_globalize', github: 'spree-contrib/spree_globalize', branch: 'master'
+gem 'spree_i18n', github: 'spree-contrib/spree_i18n'
+gem 'spree_globalize', github: 'spree-contrib/spree_globalize'
 ```
 
 Run `bundle install`
@@ -37,8 +38,8 @@ vendor/assets/javascripts/spree/backend/all.js
 vendor/assets/javascripts/spree/frontend/all.js
 //= require spree/frontend/spree_globalize
 
-vendor/assets/stylesheets/spree/frontend/all.css
-*= require spree/frontend/spree_globalize
+vendor/assets/stylesheets/spree/backend/all.css
+*= require spree/backend/spree_globalize
 ```
 
 ---
@@ -59,7 +60,7 @@ listed to customers on the frontend. You can set them on an initializer. e.g.
 
 ```ruby
 SpreeI18n::Config.available_locales = [:en, :es, :'pt-BR'] # displayed on frontend select box
-SpreeGlobalize::Config.supported_locales = [:en, :'pt-BR'] # displayed on translation forms
+SpreeGlobalize::Config.supported_locales = [:en, :es, :'pt-BR'] # displayed on translation forms
 ```
 
 NOTE for early adopters: `Spree::Globalize` namespace is now `SpreeGlobalize`

--- a/app/assets/javascripts/spree/frontend/spree_globalize.js
+++ b/app/assets/javascripts/spree/frontend/spree_globalize.js
@@ -1,2 +1,1 @@
-//= require spree/frontend
-//= require_tree .
+//= require spree/frontend/spree_i18n

--- a/gemfiles/spree_3_2.gemfile
+++ b/gemfiles/spree_3_2.gemfile
@@ -3,9 +3,7 @@
 source "https://rubygems.org"
 
 gem "spree", "~> 3.2.0"
-gem "globalize", github: "globalize/globalize", branch: "master"
-gem "activemodel-serializers-xml"
-gem "spree_i18n", github: "spree-contrib/spree_i18n"
-gem "rails-controller-testing"
+gem 'globalize', github: 'globalize/globalize'
+gem 'spree_i18n', github: 'spree-contrib/spree_i18n'
 
 gemspec path: "../"

--- a/gemfiles/spree_3_4.gemfile
+++ b/gemfiles/spree_3_4.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "spree", "~> 3.3.0"
+gem 'spree', "~> 3.4.0"
 gem 'globalize', github: 'globalize/globalize'
 gem 'spree_i18n', github: 'spree-contrib/spree_i18n'
 

--- a/gemfiles/spree_master.gemfile
+++ b/gemfiles/spree_master.gemfile
@@ -3,9 +3,7 @@
 source "https://rubygems.org"
 
 gem "spree", github: "spree/spree", branch: "master"
-gem "globalize", github: "globalize/globalize", branch: "master"
-gem "activemodel-serializers-xml"
-gem "spree_i18n", github: "spree-contrib/spree_i18n"
-gem "rails-controller-testing"
+gem 'globalize', github: 'globalize/globalize'
+gem 'spree_i18n', github: 'spree-contrib/spree_i18n'
 
 gemspec path: "../"

--- a/lib/generators/spree_globalize/install/install_generator.rb
+++ b/lib/generators/spree_globalize/install/install_generator.rb
@@ -5,7 +5,8 @@ module SpreeGlobalize
 
       def add_javascripts
         append_file "vendor/assets/javascripts/spree/backend/all.js", "//= require spree/backend/spree_globalize\n"
-      end
+        append_file "vendor/assets/javascripts/spree/frontend/all.js", "//= require spree/frontend/spree_globalize\n"
+			end
 
       def add_stylesheets
         inject_into_file 'vendor/assets/stylesheets/spree/backend/all.css', " *= require spree/backend/spree_globalize\n", before: /\*\//, verbose: true


### PR DESCRIPTION
Bug Fix: 
Updated install generator to append frontend js, and use the js file from the dependant spree_i18n extension.
This gets the language drop down selector on the front end working without needing to run the exec installer for spree_i18n.

Updated ReadMe file to accurately reflect the changes that take place when install is run, and also prompting users to add spree_i18n gem, this stops the bundle install requirement issues.

Added testing for Spree 3.4 and allowed failures of master build.

Set main gemfile and appraisal gem files to use stable version of globalize gem, not pre-release code version.