### PR TITLE
#18 Remove failing Localeapp flags images from forms

### DIFF
--- a/app/views/spree/admin/translations/_form_fields.html.erb
+++ b/app/views/spree/admin/translations/_form_fields.html.erb
@@ -9,12 +9,6 @@
 
               <div class="pull-right text-muted">
                 <small><i><%= Spree.t(:'i18n.this_file_language') %></i></small>
-
-                <% if locale.to_s.include?('-') %>
-                  <img src="https://www.localeapp.com/assets/flags/regions/<%= locale.to_s.split('-').last %>.png">
-                <% else %>
-                  <img src="https://www.localeapp.com/assets/flags/languages/<%= locale %>.png">
-                <% end %>
               </div>
             <% end %>
           </div>


### PR DESCRIPTION
It's been a while since the Localeapp flags image haven't been working properly due to changes in Localeapp. 
As stated in issue #18 by @tvdeyen having flags for locales is also not the best approach in general. 

In this pull request, I have simply removed the failing flags images from the form fields. 