### PR TITLE
Added Deface as dependency

### DIFF
--- a/spree_globalize.gemspec
+++ b/spree_globalize.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
+  s.add_runtime_dependency 'deface', '~> 1.0'
   s.add_runtime_dependency 'friendly_id-globalize'
   s.add_runtime_dependency 'globalize'
   s.add_runtime_dependency 'spree_i18n'


### PR DESCRIPTION
Since Spree 4.0 [doesn't require deface](https://github.com/spree/spree/pull/9394) we need to require it here