### PR TITLE
Update translation style 

### DIFF
--- a/app/overrides/spree/admin/shared/_product_tabs/add_translations.rb
+++ b/app/overrides/spree/admin/shared/_product_tabs/add_translations.rb
@@ -3,8 +3,8 @@ Deface::Override.new(
   name:          'product_tabs_translation',
   insert_bottom: "[data-hook='admin_product_tabs']",
   text:          <<-HTML
-                  <li class="<%= 'active' if current == 'Translations' %> nav-link">
-                    <%= link_to_with_icon 'translate', Spree.t(:'i18n.translations'), spree.admin_translations_url('products', @product.slug), title: Spree.t(:'i18n.translations') %>
+                  <li>
+                    <%= link_to_with_icon 'translate', Spree.t(:'i18n.translations'), spree.admin_translations_url('products', @product.slug), title: Spree.t(:'i18n.translations'), class: "\#\{'active' if current == 'Translations'\} nav-link" %>
                   </li>
                 HTML
 )


### PR DESCRIPTION
Now the result looks like the from the original theme. 

Before:
![before](https://user-images.githubusercontent.com/1407908/76129687-dfb6a200-5fbc-11ea-9492-1dbb92c780d5.png)

After:
![after](https://user-images.githubusercontent.com/1407908/76129694-e3e2bf80-5fbc-11ea-9ab1-1afcf87acdb1.png)

