### PR TITLE
Fix generated slugs being overwritten by globalize stash

### DIFF
--- a/app/models/spree/product_decorator.rb
+++ b/app/models/spree/product_decorator.rb
@@ -43,6 +43,7 @@ module Spree
     private
 
     def duplicate_translations(old_product)
+      globalize.reset # Stash contains copied slugs of the product that's being duplicated
       old_product.translations.each do |translation|
         translation.slug = nil # slug must be regenerated
         self.translations << translation.dup


### PR DESCRIPTION
### Issue
The globalize stash contains values of the duplicated product's slug translations and thus overwrites re-generated slugs of the copy.

### Outcome
Creating a copy of a product results in a duplicate with the default slug translation being `nil` and the rest of them being an exact copy of the original's. This makes it impossible to access or remove the copy without removing the original first since slugs of both the original product and the copy are the same.

### Description

Spree Globalize injects custom behaviour into Spree's product duplication:
https://github.com/spree-contrib/spree_globalize/blob/c7e9e5fff9a5e4bc51d53293f679c5954be1a229/app/models/spree/product_decorator.rb#L35-L37

https://github.com/spree-contrib/spree_globalize/blob/c7e9e5fff9a5e4bc51d53293f679c5954be1a229/app/models/spree/product_decorator.rb#L45-L49

`translation.dup` [(permalink)](https://github.com/globalize/globalize/blob/bcfa30f58eb2d85648bf21fc4c632754915f9edb/lib/globalize/active_record/instance_methods.rb#L114-L121) populates the Globalize stash with the original's translations. This is the cause of the problem since the slugs are translatable but we don't want to make an exact copy of them.

After saving the duplicate, the `save_translations!` method [(permalink)](https://github.com/globalize/globalize/blob/bcfa30f58eb2d85648bf21fc4c632754915f9edb/lib/globalize/active_record/adapter.rb#L36-L49) in Globalize Adapter that is called. Since it runs after we already saved our copy with slugs generated by `slug_candidates`, the slugs we generated get overwritten by exact copies of the original product.

One of the slugs is nil probably because of how `product.dup` in [ProductDuplicator](https://github.com/spree/spree/blob/fad2df617ae8622c3e60c10b590b128ce18d5901/core/lib/spree/core/product_duplicator.rb#L27-L38) and works.

### Steps to reproduce
1. Create a product
2. For every locale, assign a slug to the product
3. Click "Copy" in the product's row

You should see a "success" notification and be redirected to the original product's page.