### PR TITLE
add description, address fields to store decorator

### DIFF
--- a/app/models/spree/store_decorator.rb
+++ b/app/models/spree/store_decorator.rb
@@ -1,7 +1,7 @@
 module Spree::StoreDecorator
   def self.prepended(base)
     if ::ApplicationRecord.connected? && ::ApplicationRecord.connection.table_exists?(:spree_store_translations)
-      base.translates :name, :meta_description, :meta_keywords, :seo_title, fallbacks_for_empty_translations: true
+      base.translates :name, :meta_description, :meta_keywords, :seo_title, :description, :address, fallbacks_for_empty_translations: true
     end
   end
 


### PR DESCRIPTION
i've added those fields because i found a need of them. Im using greek language on my translations and i cant use latin chars on those fields