### PR TITLE
Preload using with_translations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,8 @@
 source 'https://rubygems.org'
 
-gem 'spree', github: 'spree/spree', branch: 'master'
+gem 'spree', github: 'spree/spree', branch: 'main'
+gem 'spree_frontend', github: 'spree/spree', branch: 'main'
+gem 'spree_backend', github: 'spree/spree', branch: 'main'
 gem 'spree_i18n', github: 'spree-contrib/spree_i18n'
 
 gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -4,7 +4,7 @@ require 'rake/testtask'
 require 'rake/packagetask'
 require 'rubygems/package_task'
 require 'rspec/core/rake_task'
-require 'spree/testing_support/common_rake'
+require 'spree/testing_support/extension_rake'
 
 Bundler::GemHelper.install_tasks
 RSpec::Core::RakeTask.new
@@ -20,5 +20,5 @@ end
 desc 'Generates a dummy app for testing'
 task :test_app do
   ENV['LIB_NAME'] = 'spree_globalize'
-  Rake::Task['common:test_app'].invoke
+  Rake::Task['extension:test_app'].invoke
 end

--- a/app/models/concerns/spree_globalize/translatable.rb
+++ b/app/models/concerns/spree_globalize/translatable.rb
@@ -31,7 +31,7 @@ module SpreeGlobalize
 
       # preload translations
       def spree_base_scopes
-        super.includes(:translations).references(:translations)
+        super #.includes(:translations).references(:translations)
       end
     end
   end

--- a/app/models/concerns/spree_globalize/translatable.rb
+++ b/app/models/concerns/spree_globalize/translatable.rb
@@ -31,7 +31,7 @@ module SpreeGlobalize
 
       # preload translations
       def spree_base_scopes
-        super #.includes(:translations).references(:translations)
+        super.with_translations
       end
     end
   end

--- a/gemfiles/spree_4_2.gemfile
+++ b/gemfiles/spree_4_2.gemfile
@@ -3,6 +3,6 @@
 source "https://rubygems.org"
 
 gem 'spree', '~> 4.2.0.rc4'
-gem 'spree_i18n', github: 'spree-contrib/spree_i18n'
+gem 'spree_i18n', github: 'spree-contrib/spree_i18n', branch: 'main'
 
 gemspec path: '../'

--- a/gemfiles/spree_master.gemfile
+++ b/gemfiles/spree_master.gemfile
@@ -2,7 +2,9 @@
 
 source "https://rubygems.org"
 
-gem 'spree', github: 'spree/spree', branch: 'master'
+gem 'spree', github: 'spree/spree', branch: 'main'
+gem 'spree_frontend', github: 'spree/spree', branch: 'main'
+gem 'spree_backend', github: 'spree/spree', branch: 'main'
 gem 'spree_i18n', github: 'spree-contrib/spree_i18n'
 
 gemspec path: '../'

--- a/gemfiles/spree_master.gemfile
+++ b/gemfiles/spree_master.gemfile
@@ -5,6 +5,6 @@ source "https://rubygems.org"
 gem 'spree', github: 'spree/spree', branch: 'main'
 gem 'spree_frontend', github: 'spree/spree', branch: 'main'
 gem 'spree_backend', github: 'spree/spree', branch: 'main'
-gem 'spree_i18n', github: 'spree-contrib/spree_i18n'
+gem 'spree_i18n', github: 'spree-contrib/spree_i18n', branch: 'main'
 
 gemspec path: '../'

--- a/spec/features/translations_spec.rb
+++ b/spec/features/translations_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature "Translations" do
   end
 
   context 'product' do
-    let!(:store) { create(:store, default: true, default_locale: 'pt-BR', supported_locales: 'pt-BR') }
+    let!(:store) { create(:store, default: true, default_locale: 'pt-BR', supported_locales: 'pt-BR', url:'http://www.example.com') }
     let!(:product) do
       create(:product,
         name: 'Antimatter',
@@ -22,12 +22,12 @@ RSpec.feature "Translations" do
       )
     end
 
-    scenario 'displays translated product page' do
+    scenario 'displays translated product page', js: true do
       visit '/products/antimatter'
       expect(page.title).to have_content('Antimatéria')
     end
 
-    scenario 'displays translated products list' do
+    scenario 'displays translated products list', js: true do
       visit '/products'
       expect(page).to have_content('Antimatéria')
     end


### PR DESCRIPTION
Fixes #90

Navigating to a taxon view in spree_frontend (any URL like /t/taxon_name) where products should be returned raised PG::GroupingError: ERROR: column "spree_product_translations.id" must appear in the GROUP BY clause or be used in an aggregate function

Removing the .includes(:translations).references(:translations) from the spree_base_scopes method in SpreeGlobalize::Translatable allows the query to succeed, but causes n+1 queries.

Adding .with_translations to the spree_base_scopes method in SpreeGlobalize::Translatable allows the query to succeed, without n+1 queries.