### PR TITLE
respect Spree.admin_path config

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Spree::Core::Engine.add_routes do
-  namespace :admin do
+  namespace :admin, path: Spree.admin_path do
     get '/:resource/:resource_id/translations' => 'translations#index', as: :translations
     patch '/option_values/:id' => 'option_values#update', as: :option_type_option_value
     patch 'product/:id/product_properties/:id' => "product_properties#translate", as: :translate_product_property


### PR DESCRIPTION
Spree has a config setting "admin_path", which this gem does not respect for the admin routes. I have /admin/ blocked in nginx because bot crawlers are really annoying.